### PR TITLE
RefreshControl fix

### DIFF
--- a/Source/SlideOutable.swift
+++ b/Source/SlideOutable.swift
@@ -455,6 +455,8 @@ open class SlideOutable: ClearContainerView {
 extension SlideOutable {
     fileprivate func scrollViewDidScroll(_ scrollView: UIScrollView) {
 
+        guard scrollView.isDragging || scrollView.isDecelerating else { return }
+
         lastActiveScroll = scrollView
 
         switch interaction(scrollView: scrollView) {
@@ -470,7 +472,9 @@ extension SlideOutable {
                 lastScrollOffset = 0
             }
             scrollView.showsVerticalScrollIndicator = false
-            scrollView.contentOffset.y = lastScrollOffset
+            if lastScrollOffset >= 0 {
+                scrollView.contentOffset.y = lastScrollOffset
+            }
         }
     }
 }


### PR DESCRIPTION
manipulate scrollDidScroll only when user interacting
additional check to avoid negative contentOffsets which fixes UI glitch when user first touches the scrollView