### PR TITLE
Avoid setting scrollView.contentOffset.y directly during scroll

### DIFF
--- a/Sources/SlideOutable/SlideOutable.swift
+++ b/Sources/SlideOutable/SlideOutable.swift
@@ -471,7 +471,10 @@ extension SlideOutable {
             }
             scrollView.showsVerticalScrollIndicator = false
             if lastScrollOffset >= 0 {
-                scrollView.contentOffset.y = lastScrollOffset
+                DispatchQueue.main.async { [weak scrollView] in
+                    guard let scrollView else { return }
+                    scrollView.setContentOffset(CGPoint(x: scrollView.contentOffset.x, y: self.lastScrollOffset), animated: false)
+                }
             }
         }
     }

--- a/Sources/SlideOutable/SlideOutable.swift
+++ b/Sources/SlideOutable/SlideOutable.swift
@@ -471,8 +471,10 @@ extension SlideOutable {
             }
             scrollView.showsVerticalScrollIndicator = false
             if lastScrollOffset >= 0 {
-                DispatchQueue.main.async { [weak scrollView] in
-                    guard let scrollView else { return }
+                // Updating contentOffset asynchronously helps prevent crashes during active scrolling
+                // by ensuring the update occurs on the main thread and avoids potential race conditions.
+                DispatchQueue.main.async { [weak self, weak scrollView] in
+                    guard let self = self, let scrollView = scrollView else { return }
                     scrollView.setContentOffset(CGPoint(x: scrollView.contentOffset.x, y: self.lastScrollOffset), animated: false)
                 }
             }


### PR DESCRIPTION
Sometimes resulted with a crash if view layout was triggered while actively scrolling

<img width="1613" alt="Screenshot 2025-05-07 at 11 03 46" src="https://github.com/user-attachments/assets/3d185136-e56a-436d-86ae-649d3fc95278" />
